### PR TITLE
add hash_object.py for file hashing functionality

### DIFF
--- a/src/plumbing/hash_object.py
+++ b/src/plumbing/hash_object.py
@@ -1,0 +1,42 @@
+import sys
+import os
+import hashlib
+import zlib
+
+
+def hash_object(file_path, git_dir=".git", write=True):
+    if not os.path.isfile(file_path):
+        print(f"Erreur : '{file_path}' est introuvable ou n'est pas un fichier.", file=sys.stderr)
+        sys.exit(1)
+
+    with open(file_path, 'rb') as f:
+        data = f.read()
+
+    header = f"blob {len(data)}\0".encode()
+
+    full_data = header + data
+
+    sha1 = hashlib.sha1(full_data).hexdigest()
+
+    if write:
+        # Répertoire .git/objects/<xx>/<yyyyyy...>
+        obj_dir = os.path.join(git_dir, "objects", sha1[:2])
+        obj_path = os.path.join(obj_dir, sha1[2:])
+
+
+        compressed = zlib.compress(full_data)
+
+        with open(obj_path, 'wb') as f:
+            f.write(compressed)
+
+    print(sha1)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python hash_object.py <file_path> [<git_dir>]", file=sys.stderr)
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    git_dir = sys.argv[2] if len(sys.argv) > 2 else ".git"
+
+    hash_object(file_path, git_dir)


### PR DESCRIPTION
This pull request introduces a new Python script, `hash_object.py`, which implements functionality to compute the SHA-1 hash of a file's contents in the context of Git's object storage. The script also supports writing the compressed object to the `.git/objects` directory. Below are the key changes:

### New functionality for Git object hashing:
* Added the `hash_object` function to compute the SHA-1 hash of a file's contents and optionally write the compressed object to the `.git/objects` directory. Includes error handling for invalid file paths. (`src/plumbing/hash_object.py`, [src/plumbing/hash_object.pyR1-R42](diffhunk://#diff-d5127cb39dbf34dccbd20ff0c4841516cc33cf5e41c0c8c2aa68d9d9cc91785cR1-R42))
* Implemented a command-line interface for the script, allowing users to specify the file path and optional Git directory. (`src/plumbing/hash_object.py`, [src/plumbing/hash_object.pyR1-R42](diffhunk://#diff-d5127cb39dbf34dccbd20ff0c4841516cc33cf5e41c0c8c2aa68d9d9cc91785cR1-R42))