### PR TITLE
feat/add test for unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.mygit/
+/.idea/

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Ce fichier permet à Python de reconnaître ce répertoire comme un package
+

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -1,0 +1,2 @@
+# Ce fichier permet à Python de reconnaître ce répertoire comme un package
+

--- a/tests/porcelain/test_init.py
+++ b/tests/porcelain/test_init.py
@@ -1,0 +1,72 @@
+import os
+import shutil
+import unittest
+import tempfile
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from src.porcelain.init import init
+
+
+class TestInit(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_init_creates_git_directory(self):
+        init(self.test_dir)
+        git_dir = os.path.join(self.test_dir, ".mygit")
+        self.assertTrue(os.path.exists(git_dir),
+                      "Le répertoire .git n'a pas été créé")
+
+    def test_init_creates_required_subdirectories(self):
+        init(self.test_dir)
+        git_dir = os.path.join(self.test_dir, ".mygit")
+
+        required_dirs = [
+            os.path.join(git_dir, "objects"),
+            os.path.join(git_dir, "refs"),
+            os.path.join(git_dir, "refs/heads"),
+            os.path.join(git_dir, "refs/tags"),
+        ]
+
+        for d in required_dirs:
+            self.assertTrue(os.path.exists(d),
+                          f"Le répertoire {d} n'a pas été créé")
+
+    def test_init_creates_required_files(self):
+        init(self.test_dir)
+        git_dir = os.path.join(self.test_dir, ".mygit")
+
+        required_files = [
+            os.path.join(git_dir, "HEAD"),
+            os.path.join(git_dir, "config"),
+        ]
+
+        for f in required_files:
+            self.assertTrue(os.path.exists(f),
+                          f"Le fichier {f} n'a pas été créé")
+
+    def test_init_head_content(self):
+        init(self.test_dir)
+        head_path = os.path.join(self.test_dir, ".mygit", "HEAD")
+
+        with open(head_path, 'r') as f:
+            content = f.read().strip()
+
+        self.assertEqual(content, "ref: refs/heads/main",
+                        "Le fichier HEAD ne pointe pas vers refs/heads/main")
+
+    def test_init_idempotent(self):
+        result1 = init(self.test_dir)
+        result2 = init(self.test_dir)
+
+        self.assertTrue(result1, "Le premier appel à init a échoué")
+        self.assertFalse(result2, "Le deuxième appel à init devrait retourner False")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds unit tests for the `init` function in the `src.porcelain.init` module and includes minor structural changes to recognize directories as Python packages. The most significant changes are the addition of comprehensive test cases to ensure the correctness and robustness of the `init` function.

### Unit Tests for `init` Function:

* [`tests/porcelain/test_init.py`](diffhunk://#diff-f3c4ab3bcedc75a6ca4740ba18def7d82552b139e00bea9775bd00047c182e6eR1-R72): Added a new test suite using Python's `unittest` framework to validate the behavior of the `init` function. Tests cover the creation of `.mygit` directory, required subdirectories (`objects`, `refs`, `refs/heads`, `refs/tags`), required files (`HEAD`, `config`), correct content of the `HEAD` file, and idempotency of the `init` function.

### Structural Changes:

* [`tests/__init__.py`](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dR1-R2): Added an empty `__init__.py` file to mark the `tests` directory as a Python package.
* [`tests/porcelain/__init__.py`](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dR1-R2): Added an empty `__init__.py` file to mark the `tests/porcelain` directory as a Python package.