### PR TITLE
implement CLI for mygit with init and hash-object commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,20 @@
+import typer
+import sys
+import os
+
+# Ajout du chemin du projet au sys.path pour pouvoir importer les modules
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+from src.porcelain.init import init as init_func
+
+app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
+
+@app.command()
+def init(
+    path: str = typer.Argument(".", help="Chemin où initialiser le dépôt")
+):
+    init_func(path)
+    typer.echo(f"Dépôt Git initialisé dans {path}")
+
+if __name__ == "__main__":
+    app()

--- a/mygit/__init__.py
+++ b/mygit/__init__.py
@@ -1,0 +1,5 @@
+"""
+HeticGit - Une implémentation de Git en Python
+"""
+
+__version__ = "0.1.0"

--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -1,0 +1,38 @@
+import typer
+import sys
+import os
+from typing import Optional
+
+# Ajout du chemin du projet au sys.path pour pouvoir importer les modules
+sys.path.append(os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from src.porcelain.init import init as init_func
+from src.plumbing.hash_object import hash_object as hash_object_func
+
+app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
+
+plumbing_app = typer.Typer(help="Commandes plumbing (bas niveau)")
+app.add_typer(plumbing_app, name="plumbing")
+
+@app.command()
+def init(
+    path: str = typer.Argument(".", help="Chemin où initialiser le dépôt")
+):
+    init_func(path)
+    typer.echo(f"Dépôt Git initialisé dans {path}")
+
+@app.command("hash-object")
+@plumbing_app.command("hash-object")
+def hash_object(
+    file: str = typer.Argument(..., help="Fichier à hasher"),
+    write: bool = typer.Option(False, "--write", "-w", help="Écrire l'objet dans la base de données Git")
+):
+
+    hash_object_func(file, write=write)
+    if write:
+        typer.echo(f"Hash du fichier {file} calculé et écrit dans la base de données")
+    else:
+        typer.echo(f"Hash du fichier {file} calculé")
+
+if __name__ == "__main__":
+    app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+typer>=0.16.0
+shellingham>=1.3.0
+click>=8.0.0
+pytest>=7.0.0
+rich>=10.11.0
+typing-extensions>=3.7.4.3
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="mygit",
+    version="0.1.0",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        "typer>=0.16.0",
+        "shellingham>=1.3.0",
+    ],
+    entry_points="""
+        [console_scripts]
+        mygit=mygit.cli:app
+    """,
+)

--- a/src/plumbing/hash_object.py
+++ b/src/plumbing/hash_object.py
@@ -4,7 +4,7 @@ import hashlib
 import zlib
 
 
-def hash_object(file_path, git_dir=".mygit", write=True):
+def hash_object(file_path, git_dir=".mygit", write=False):
     if not os.path.isfile(file_path):
         print(f"Erreur : '{file_path}' est introuvable ou n'est pas un fichier.", file=sys.stderr)
         sys.exit(1)
@@ -23,7 +23,6 @@ def hash_object(file_path, git_dir=".mygit", write=True):
         obj_dir = os.path.join(git_dir, "objects", sha1[:2])
         obj_path = os.path.join(obj_dir, sha1[2:])
 
-        # Créer le répertoire s'il n'existe pas
         os.makedirs(obj_dir, exist_ok=True)
 
         compressed = zlib.compress(full_data)


### PR DESCRIPTION
This pull request introduces a new Python-based Git implementation called `mygit`. The changes include adding CLI functionality, defining project metadata, integrating plumbing commands, and setting up the package for distribution. The most important changes are the creation of the CLI interface, the addition of plumbing commands, and modifications to the `hash_object` function.

### CLI Functionality:
* [`cli.py`](diffhunk://#diff-7648f5f4cce4bf01d02de43f8c5f6f2130b787baece0cf6338210496d8bdfcdcR1-R20): Added a CLI interface using `typer`, with an `init` command to initialize a Git repository.
* [`mygit/cli.py`](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R1-R38): Expanded the CLI to include plumbing commands, such as `hash-object`, which calculates and optionally writes the hash of a file to the Git database.

### Plumbing Commands:
* [`src/plumbing/hash_object.py`](diffhunk://#diff-d5127cb39dbf34dccbd20ff0c4841516cc33cf5e41c0c8c2aa68d9d9cc91785cL7-R7): Modified the `hash_object` function to default the `write` parameter to `False` and removed redundant directory creation comments. [[1]](diffhunk://#diff-d5127cb39dbf34dccbd20ff0c4841516cc33cf5e41c0c8c2aa68d9d9cc91785cL7-R7) [[2]](diffhunk://#diff-d5127cb39dbf34dccbd20ff0c4841516cc33cf5e41c0c8c2aa68d9d9cc91785cL26)

### Project Metadata and Distribution:
* [`mygit/__init__.py`](diffhunk://#diff-b71cc50755ffbba6b0e689eede376b1cb74077053c700baefe6ca935fb4ff27bR1-R5): Added metadata, including the project description and version number.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R1-R16): Configured the package for distribution using `setuptools`, including dependencies and entry points for the CLI.