### PR TITLE
add type and pretty-print options to cat-file command in CLI

### DIFF
--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -10,6 +10,8 @@ from src.porcelain.init import init as init_func
 from src.plumbing.hash_object import hash_object as hash_object_func
 from src.plumbing.cat_file import cat_file as cat_file_func
 from src.porcelain.add import add as add_func
+from src.plumbing.commit_tree import commit_tree as commit_tree_func
+from src.plumbing.write_tree import write_tree as write_tree_func
 
 app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
 
@@ -57,6 +59,26 @@ def cat_file(
         raise typer.Exit(1)
     opt = "-t" if type_ else "-p"
     cat_file_func(oid, opt, git_dir)
+
+@app.command("commit-tree")
+@plumbing_app.command("commit-tree")
+def commit_tree_cmd(
+    tree_sha: str = typer.Argument(..., help="SHA de l'objet tree"),
+    message: str = typer.Option(..., "-m", "--message", help="Message du commit"),
+    parent: str = typer.Option(None, "-p", "--parent", help="SHA du commit parent"),
+    git_dir: str = typer.Option(".mygit", help="Chemin du dossier .mygit")
+):
+    """Crée un objet commit à partir d'un tree et écrit son oid sur stdout."""
+    commit_tree_func(tree_sha, message, parent, git_dir)
+
+@app.command("write-tree")
+@plumbing_app.command("write-tree")
+def write_tree_cmd(
+    git_dir: str = typer.Option(".mygit", help="Chemin du dossier .mygit"),
+    index_path: str = typer.Option(".mygit/index", help="Chemin du fichier d'index")
+):
+    """Crée un objet tree à partir de l'index et affiche son SHA-1."""
+    write_tree_func(git_dir, index_path)
 
 if __name__ == "__main__":
     app()

--- a/src/plumbing/__init__.py
+++ b/src/plumbing/__init__.py
@@ -1,2 +1,4 @@
 from .cat_file import cat_file
 from .hash_object import hash_object
+from .commit_tree import commit_tree
+from .write_tree import write_tree

--- a/src/plumbing/commit_tree.py
+++ b/src/plumbing/commit_tree.py
@@ -1,0 +1,42 @@
+import sys
+import os
+import hashlib
+import zlib
+from datetime import datetime
+
+def commit_tree(tree_sha, message, parent=None, git_dir=".mygit"):
+    # Construction du contenu du commit
+
+    lines = [f"tree {tree_sha}"]
+    if parent:
+        lines.append(f"parent {parent}")
+    author = f"Author <author@example.com> {int(datetime.now().timestamp())} +0000"
+    committer = author
+    lines.append(f"author {author}")
+    lines.append(f"committer {committer}")
+    lines.append("")
+    lines.append(message)
+    content = "\n".join(lines).encode()
+    header = f"commit {len(content)}\0".encode()
+    full_data = header + content
+    sha1 = hashlib.sha1(full_data).hexdigest()
+    # Écriture de l'objet
+
+    obj_dir = os.path.join(git_dir, "objects", sha1[:2])
+    obj_path = os.path.join(obj_dir, sha1[2:])
+    os.makedirs(obj_dir, exist_ok=True)
+    compressed = zlib.compress(full_data)
+    with open(obj_path, 'wb') as f:
+        f.write(compressed)
+    print(sha1)
+    return sha1
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Create a commit object")
+    parser.add_argument("tree_sha", help="SHA of the tree object")
+    parser.add_argument("-m", "--message", required=True, help="Commit message")
+    parser.add_argument("-p", "--parent", help="Parent commit SHA")
+    parser.add_argument("--git-dir", default=".mygit", help="Git directory")
+    args = parser.parse_args()
+    commit_tree(args.tree_sha, args.message, args.parent, args.git_dir) 

--- a/src/plumbing/hash_object.py
+++ b/src/plumbing/hash_object.py
@@ -33,6 +33,22 @@ def hash_object(file_path, git_dir=".mygit", write=False):
     print(sha1)
     return sha1
 
+def hash_object_data(data, obj_type, git_dir=".mygit", write=False):
+    if isinstance(data, str):
+        data = data.encode()
+    header = f"{obj_type} {len(data)}\0".encode()
+    full_data = header + data
+    sha1 = hashlib.sha1(full_data).hexdigest()
+    if write:
+        obj_dir = os.path.join(git_dir, "objects", sha1[:2])
+        obj_path = os.path.join(obj_dir, sha1[2:])
+        os.makedirs(obj_dir, exist_ok=True)
+        compressed = zlib.compress(full_data)
+        with open(obj_path, 'wb') as f:
+            f.write(compressed)
+    print(sha1)
+    return sha1
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python hash_object.py <file_path> [<git_dir>]", file=sys.stderr)

--- a/src/plumbing/write_tree.py
+++ b/src/plumbing/write_tree.py
@@ -1,0 +1,17 @@
+import os
+from src.plumbing.hash_object import hash_object_data
+
+def write_tree(git_dir=".mygit", index_path=".mygit/index"):
+    entries = []
+    with open(index_path) as idx:
+        for line in idx:
+            mode, path, sha1 = line.strip().split()
+            # Format attendu : <mode> <nom>\0<sha1 binaire>
+            entry = f"{mode} {path}".encode() + b"\0" + bytes.fromhex(sha1)
+            entries.append(entry)
+    tree_content = b"".join(entries)
+    tree_sha1 = hash_object_data(tree_content, "tree", git_dir, write=True)
+    print(tree_sha1)
+
+if __name__ == "__main__":
+    write_tree()

--- a/tests/plumbing/test_commit_tree.py
+++ b/tests/plumbing/test_commit_tree.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+import tempfile
+import unittest
+import sys
+import io
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+from src.plumbing.commit_tree import commit_tree
+
+class TestCommitTree(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.git_dir = os.path.join(self.test_dir, ".mygit")
+        os.makedirs(os.path.join(self.git_dir, "objects"), exist_ok=True)
+        # Créer un tree SHA bidon
+        self.tree_sha = "a" * 40
+        self.parent_sha = "b" * 40
+        self.message = "Initial commit"
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_commit_tree_no_parent(self):
+        captured = io.StringIO()
+        sys.stdout = captured
+        oid = commit_tree(self.tree_sha, self.message, None, self.git_dir)
+        sys.stdout = sys.__stdout__
+        self.assertEqual(captured.getvalue().strip(), oid)
+        # Vérifie que l'objet a bien été écrit
+        obj_path = os.path.join(self.git_dir, "objects", oid[:2], oid[2:])
+        self.assertTrue(os.path.exists(obj_path))
+
+    def test_commit_tree_with_parent(self):
+        captured = io.StringIO()
+        sys.stdout = captured
+        oid = commit_tree(self.tree_sha, self.message, self.parent_sha, self.git_dir)
+        sys.stdout = sys.__stdout__
+        self.assertEqual(captured.getvalue().strip(), oid)
+        obj_path = os.path.join(self.git_dir, "objects", oid[:2], oid[2:])
+        self.assertTrue(os.path.exists(obj_path))
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
This pull request introduces two new plumbing commands, `commit-tree` and `write-tree`, to the `mygit` CLI, along with their implementations and tests. These additions enhance the functionality of the `mygit` tool by enabling the creation of commit and tree objects. Additionally, a helper function for hashing arbitrary data has been added to support these features.

### New Plumbing Commands:

* **`commit-tree` Command**:
  - Added to `mygit/cli.py` to create a commit object from a tree object, with optional parent commit support. (`[mygit/cli.pyR63-R82](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R63-R82)`)
  - Implemented in `src/plumbing/commit_tree.py`, including functionality for constructing commit objects, writing them to the `.mygit/objects` directory, and returning the SHA-1 of the created object. (`[src/plumbing/commit_tree.pyR1-R42](diffhunk://#diff-c05a52efaf5345bb51c59d5872f15807e9c7c5a1723e51be128ba9d5fecfc87aR1-R42)`)
  - Unit tests for `commit-tree` added in `tests/plumbing/test_commit_tree.py`, covering cases with and without a parent commit. (`[tests/plumbing/test_commit_tree.pyR1-R44](diffhunk://#diff-8c97f4eddc34739e72b61956a7cff2fab3323cae04102dba997432a437f18f5eR1-R44)`)

* **`write-tree` Command**:
  - Added to `mygit/cli.py` to create a tree object from the index file and display its SHA-1. (`[mygit/cli.pyR63-R82](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R63-R82)`)
  - Implemented in `src/plumbing/write_tree.py`, which reads the index file, formats entries, and writes the tree object to the `.mygit/objects` directory. (`[src/plumbing/write_tree.pyR1-R17](diffhunk://#diff-98e1eebc583e8cf235323460554b87829362e7abfae676f5b5a5c0d9336fa267R1-R17)`)

### Supporting Changes:

* **Helper Function for Hashing Data**:
  - Added `hash_object_data` function in `src/plumbing/hash_object.py` to hash arbitrary data and optionally write it as a Git object. This is used by the `write-tree` implementation. (`[src/plumbing/hash_object.pyR36-R51](diffhunk://#diff-d5127cb39dbf34dccbd20ff0c4841516cc33cf5e41c0c8c2aa68d9d9cc91785cR36-R51)`)

* **Module Initialization**:
  - Updated `src/plumbing/__init__.py` to include the new `commit_tree` and `write_tree` functions for easier imports. (`[src/plumbing/__init__.pyR3-R4](diffhunk://#diff-7b3cdcb1db6206f5ad8bcbea192e717e41a6f09127a2b5fd48506f85fb8543b9R3-R4)`)