### PR TITLE
add ls-files command to CLI and implement functionality to list files…

### DIFF
--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -10,6 +10,7 @@ from src.plumbing.hash_object import hash_object as hash_object_func
 from src.plumbing.cat_file import cat_file as cat_file_func
 from src.porcelain.add import add as add_func
 from src.plumbing.commit_tree import commit_tree as commit_tree_func
+from src.plumbing.ls_files import ls_files as ls_files_func
 
 app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
 
@@ -73,6 +74,11 @@ def commit_tree_cmd(
 ):
     """Crée un objet commit à partir d'un tree et écrit son oid sur stdout."""
     commit_tree_func(tree_sha, message, parent, git_dir)
+
+@app.command("ls-files")
+def ls_files_cmd():
+    """Liste tous les fichiers dans l'index (comme git ls-files)"""
+    ls_files_func()
 
 if __name__ == "__main__":
     app()

--- a/src/plumbing/__init__.py
+++ b/src/plumbing/__init__.py
@@ -2,3 +2,4 @@ from .cat_file import cat_file
 from .hash_object import hash_object
 from .commit_tree import commit_tree
 from .write_tree import write_tree
+from .ls_files import ls_files

--- a/src/plumbing/ls_files.py
+++ b/src/plumbing/ls_files.py
@@ -1,0 +1,15 @@
+import sys
+
+def ls_files(index_path=".mygit/index"):
+    try:
+        with open(index_path) as idx:
+            for line in idx:
+                parts = line.strip().split()
+                if len(parts) >= 2:
+                    print(parts[1])
+    except FileNotFoundError:
+        print(f"Index file not found: {index_path}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    ls_files() 

--- a/tests/plumbing/test_ls_files.py
+++ b/tests/plumbing/test_ls_files.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import tempfile
+import unittest
+import sys
+import io
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+from src.plumbing.ls_files import ls_files
+
+class TestLsFiles(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.index_path = os.path.join(self.test_dir, "index")
+        # Create a fake index file
+        with open(self.index_path, 'w') as f:
+            f.write("100644 file1.txt deadbeef\n")
+            f.write("100644 dir/file2.txt cafebabe\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_ls_files(self):
+        captured = io.StringIO()
+        sys.stdout = captured
+        ls_files(self.index_path)
+        sys.stdout = sys.__stdout__
+        output = captured.getvalue().strip().split('\n')
+        self.assertIn("file1.txt", output)
+        self.assertIn("dir/file2.txt", output)
+        self.assertEqual(len(output), 2)
+
+    def test_ls_files_missing_index(self):
+        missing_path = os.path.join(self.test_dir, "noindex")
+        captured = io.StringIO()
+        sys.stderr = captured
+        with self.assertRaises(SystemExit):
+            ls_files(missing_path)
+        sys.stderr = sys.__stderr__
+        self.assertIn("Index file not found", captured.getvalue())
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
This pull request introduces a new `ls-files` feature to the `mygit` CLI, which lists all files in the index, similar to the `git ls-files` command. The changes include implementing the functionality, integrating it into the CLI, and adding tests to ensure its correctness.

### New `ls-files` Feature:

* **Implementation of `ls_files` function**: Added a new `ls_files` function in `src/plumbing/ls_files.py` to read and list files from the index. It handles missing index files gracefully by printing an error message and exiting with a non-zero status.

* **Integration into `mygit` CLI**: 
  - Imported the `ls_files` function in `mygit/cli.py` and registered it as a new CLI command (`ls-files`). 
  - This allows users to list files in the index directly from the command line. [[1]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R13) [[2]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R78-R82)

### Test Coverage:

* **Unit tests for `ls_files`**: 
  - Added a new test suite in `tests/plumbing/test_ls_files.py` to validate the behavior of the `ls_files` function.
  - Tests include scenarios for correctly listing files and handling missing index files.

### Code Organization:

* **Exporting `ls_files` in `src.plumbing`**: Updated the `__init__.py` file in the `src/plumbing` module to include the `ls_files` function, ensuring it is accessible as part of the module's public API.… in the index