### PR TITLE
add show-ref command and implementation to list refs and their hashes

### DIFF
--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -13,6 +13,7 @@ from src.plumbing.commit_tree import commit_tree as commit_tree_func
 from src.plumbing.ls_tree import ls_tree as ls_tree_func
 from src.plumbing.write_tree import write_tree as write_tree_func
 from src.plumbing.ls_files import ls_files as ls_files_func
+from src.plumbing.show_ref import show_ref as show_ref_func
 
 app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
 
@@ -86,6 +87,12 @@ def ls_tree_cmd(tree_sha: str, git_dir: str = ".mygit"):
 def ls_files_cmd():
     """Liste tous les fichiers dans l'index (comme git ls-files)"""
     ls_files_func()
+
+@app.command("show-ref")
+@plumbing_app.command("show-ref")
+def show_ref_cmd(git_dir: str = ".mygit"):
+    """Liste toutes les refs et leurs hashes (branches et tags)"""
+    show_ref_func(git_dir)
 
 if __name__ == "__main__":
     app()

--- a/src/plumbing/__init__.py
+++ b/src/plumbing/__init__.py
@@ -3,4 +3,5 @@ from .hash_object import hash_object
 from .commit_tree import commit_tree
 from .write_tree import write_tree
 from .ls_tree import ls_tree
+from .show_ref import show_ref
 from .ls_files import ls_files

--- a/src/plumbing/show_ref.py
+++ b/src/plumbing/show_ref.py
@@ -1,0 +1,22 @@
+import os
+
+def show_ref(git_dir=".mygit"):
+    refs_dir = os.path.join(git_dir, "refs")
+    for ref_type in ["heads", "tags"]:
+        ref_path = os.path.join(refs_dir, ref_type)
+        if not os.path.isdir(ref_path):
+            continue
+        for ref_name in os.listdir(ref_path):
+            full_ref = f"refs/{ref_type}/{ref_name}"
+            ref_file = os.path.join(ref_path, ref_name)
+            try:
+                with open(ref_file, "r") as f:
+                    sha = f.read().strip()
+                print(f"{sha} {full_ref}")
+            except Exception:
+                continue
+
+if __name__ == "__main__":
+    import sys
+    git_dir = sys.argv[1] if len(sys.argv) > 1 else ".mygit"
+    show_ref(git_dir) 


### PR DESCRIPTION
This pull request introduces a new `show-ref` command to the `mygit` CLI, allowing users to list all references (branches and tags) along with their hashes. The changes include adding the necessary plumbing function and integrating it into the CLI.

### New Feature: `show-ref` Command

* **CLI Integration:**
  - Added the `show-ref` command to the `mygit` CLI by importing the `show_ref` function and defining `show_ref_cmd` to call it. (`mygit/cli.py`, [[1]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R16) [[2]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R91-R96)

* **Plumbing Function:**
  - Implemented the `show_ref` function in `src/plumbing/show_ref.py`. This function reads references (branches and tags) from the `.mygit/refs` directory, retrieves their hashes, and prints them in the format `<hash> <ref>`. (`src/plumbing/show_ref.py`, [src/plumbing/show_ref.pyR1-R22](diffhunk://#diff-2baee4a585b43f946eebead6aa72a904d27419a8b86c80b2604789c052b48b23R1-R22))

* **Module Update:**
  - Updated the plumbing module's `__init__.py` to include the new `show_ref` function, making it accessible as part of the plumbing layer. (`src/plumbing/__init__.py`, [src/plumbing/__init__.pyR6](diffhunk://#diff-7b3cdcb1db6206f5ad8bcbea192e717e41a6f09127a2b5fd48506f85fb8543b9R6))