### PR TITLE
add rev-parse command and implementation to resolve references to SHA-1

### DIFF
--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -15,6 +15,7 @@ from src.plumbing.ls_tree import ls_tree as ls_tree_func
 from src.plumbing.write_tree import write_tree as write_tree_func
 from src.plumbing.ls_files import ls_files as ls_files_func
 from src.plumbing.show_ref import show_ref as show_ref_func
+from src.plumbing.rev_parse import rev_parse as rev_parse_func
 
 app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
 
@@ -81,7 +82,7 @@ def commit_tree_cmd(
 
 @app.command("commit")
 def commit_cmd(
-    message: str = typer.Argument(..., help="Message du commit")
+    message: str = typer.Option(..., "-m", "--message", help="Message du commit")
 ):
     commit_func(message)
     typer.echo("Commit créé")
@@ -101,6 +102,15 @@ def ls_files_cmd():
 def show_ref_cmd(git_dir: str = ".mygit"):
     """Liste toutes les refs et leurs hashes (branches et tags)"""
     show_ref_func(git_dir)
+
+@app.command("rev-parse")
+@plumbing_app.command("rev-parse")
+def rev_parse_cmd(
+    ref: str = typer.Argument(..., help="Référence à résoudre (branche, HEAD, SHA-1, tag)"),
+    git_dir: str = typer.Option(".mygit", help="Chemin du dossier .mygit")
+):
+    """Résout une référence (branche, HEAD, tag, SHA-1) en SHA-1."""
+    rev_parse_func(ref, git_dir)
 
 if __name__ == "__main__":
     app()

--- a/src/plumbing/__init__.py
+++ b/src/plumbing/__init__.py
@@ -5,3 +5,4 @@ from .write_tree import write_tree
 from .ls_tree import ls_tree
 from .show_ref import show_ref
 from .ls_files import ls_files
+from .rev_parse import rev_parse

--- a/src/plumbing/rev_parse.py
+++ b/src/plumbing/rev_parse.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import re
+
+def rev_parse(ref, git_dir=".mygit"):
+    # 1. Si c'est un SHA-1 complet (40 caractères hexadécimaux)
+    if re.fullmatch(r"[0-9a-fA-F]{40}", ref):
+        obj_path = os.path.join(git_dir, "objects", ref[:2], ref[2:])
+        if os.path.exists(obj_path):
+            print(ref)
+            return ref
+        else:
+            print(f"Erreur : l'objet {ref} n'existe pas.", file=sys.stderr)
+            sys.exit(1)
+
+    # 2. Si c'est HEAD
+    if ref == "HEAD":
+        head_path = os.path.join(git_dir, "HEAD")
+        if not os.path.exists(head_path):
+            print("Erreur : HEAD introuvable.", file=sys.stderr)
+            sys.exit(1)
+        with open(head_path) as f:
+            content = f.read().strip()
+        if content.startswith("ref: "):
+            ref = content[5:].strip()
+        else:
+            # HEAD contient directement un SHA-1
+            if re.fullmatch(r"[0-9a-fA-F]{40}", content):
+                print(content)
+                return content
+            else:
+                print("Erreur : HEAD invalide.", file=sys.stderr)
+                sys.exit(1)
+
+    # 3. Si c'est une référence (branche ou tag)
+    # Cherche d'abord dans heads, puis tags, puis ref absolu
+    for ref_path in [
+        os.path.join(git_dir, "refs", "heads", ref),
+        os.path.join(git_dir, "refs", "tags", ref),
+        os.path.join(git_dir, ref) if ref.startswith("refs/") else None
+    ]:
+        if ref_path and os.path.exists(ref_path):
+            with open(ref_path) as f:
+                sha = f.read().strip()
+            print(sha)
+            return sha
+
+    print(f"Erreur : référence '{ref}' introuvable.", file=sys.stderr)
+    sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage : python rev_parse.py <ref> [<git_dir>]", file=sys.stderr)
+        sys.exit(1)
+    ref = sys.argv[1]
+    git_dir = sys.argv[2] if len(sys.argv) > 2 else ".mygit"
+    rev_parse(ref, git_dir) 

--- a/src/porcelain/commit.py
+++ b/src/porcelain/commit.py
@@ -34,6 +34,17 @@ def commit(message):
             f.write(f"  {fname}: {sha1}\n")
     print(f"Commit créé: {commit_hash}")
 
+    head_path = os.path.join(GIT_DIR, "HEAD")
+    if os.path.exists(head_path):
+        with open(head_path) as f:
+            content = f.read().strip()
+        if content.startswith("ref: "):
+            ref_rel = content[5:].strip()
+            ref_path = os.path.join(GIT_DIR, ref_rel)
+            os.makedirs(os.path.dirname(ref_path), exist_ok=True)
+            with open(ref_path, "w") as rf:
+                rf.write(commit_hash + "\n")
+
 # Pour l’intégrer à ta CLI :
 # from src.porcelain.commit import commit as commit_func
 # @app.command("commit")


### PR DESCRIPTION
This pull request introduces a new `rev-parse` command to the CLI, enhances the `commit` functionality to update branch references, and includes minor adjustments to improve usability. The most significant changes are the addition of the `rev-parse` functionality, updates to the CLI interface, and improvements to the commit behavior.

### New `rev-parse` functionality:
* Added a new `rev_parse` function in `src/plumbing/rev_parse.py` to resolve Git references (e.g., branches, HEAD, tags, SHA-1) into SHA-1 hashes. This includes handling various cases like direct SHA-1, HEAD, and references in `refs/heads` or `refs/tags`.
* Imported `rev_parse` into `src/plumbing/__init__.py` to make it accessible as part of the plumbing module.
* Registered the `rev-parse` command in `mygit/cli.py`, allowing users to resolve references via the CLI. [[1]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R18) [[2]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R106-R114)

### CLI improvements:
* Changed the `commit` command in `mygit/cli.py` to use `typer.Option` for the message parameter, enabling users to provide commit messages with `-m` or `--message` instead of a positional argument.

### Commit behavior enhancements:
* Updated the `commit` function in `src/porcelain/commit.py` to update the branch reference in `.mygit/refs/heads` when a new commit is created, ensuring the branch points to the latest commit.