### PR TITLE
add rm command and implementation to remove files from index and work…

### DIFF
--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -17,6 +17,7 @@ from src.plumbing.ls_files import ls_files as ls_files_func
 from src.plumbing.show_ref import show_ref as show_ref_func
 from src.plumbing.rev_parse import rev_parse as rev_parse_func
 from src.porcelain.log import log as log_func
+from src.porcelain.rm import rm as rm_func
 
 app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
 
@@ -117,6 +118,21 @@ def rev_parse_cmd(
 def log_cmd():
     """Affiche l'historique des commits depuis HEAD (comme git log)"""
     log_func()
+
+@app.command("rm")
+def rm_cmd(
+    file: str = typer.Argument(..., help="Fichier à supprimer de l'index et du répertoire de travail"),
+    cached: bool = typer.Option(False, "--cached", help="Ne supprimer que de l'index, pas du répertoire de travail")
+):
+    if not cached:
+        if not typer.confirm(f"Êtes-vous sûr de vouloir supprimer {file} du répertoire de travail ?"):
+            typer.echo("Suppression annulée.")
+            raise typer.Exit(0)
+    rm_func(file, cached=cached)
+    if cached:
+        typer.echo(f"Fichier {file} supprimé de l'index seulement.")
+    else:
+        typer.echo(f"Fichier {file} supprimé de l'index et du répertoire de travail.")
 
 if __name__ == "__main__":
     app()

--- a/src/porcelain/__init__.py
+++ b/src/porcelain/__init__.py
@@ -1,1 +1,2 @@
 from .log import log
+from .rm import rm

--- a/src/porcelain/rm.py
+++ b/src/porcelain/rm.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+GIT_DIR = ".mygit"
+INDEX_FILE = os.path.join(GIT_DIR, "index")
+
+def rm(file_path, git_dir=GIT_DIR, index_path=INDEX_FILE, cached=False):
+    rel_path = os.path.relpath(file_path)
+    # Remove from index
+    if not os.path.exists(index_path):
+        print(f"Index file not found: {index_path}", file=sys.stderr)
+        sys.exit(1)
+    new_lines = []
+    removed = False
+    with open(index_path, "r") as idx:
+        for line in idx:
+            parts = line.strip().split()
+            if len(parts) >= 2 and parts[1] == rel_path:
+                removed = True
+                continue  # skip this line (removes from index)
+            new_lines.append(line)
+    if not removed:
+        print(f"File '{rel_path}' not found in index.", file=sys.stderr)
+        sys.exit(1)
+    with open(index_path, "w") as idx:
+        idx.writelines(new_lines)
+    # Remove from working directory if not cached
+    if not cached:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+        else:
+            print(f"File '{file_path}' does not exist in working directory.", file=sys.stderr)
+    print(f"Removed '{rel_path}'{' from index only' if cached else ''}.")
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Remove file from working directory and index (like git rm)")
+    parser.add_argument("file_path", help="Path to the file to remove")
+    parser.add_argument("--cached", action="store_true", help="Only remove from index, not from working directory")
+    parser.add_argument("--git-dir", default=GIT_DIR, help="Path to .mygit directory")
+    args = parser.parse_args()
+    rm(args.file_path, git_dir=args.git_dir, index_path=os.path.join(args.git_dir, "index"), cached=args.cached) 


### PR DESCRIPTION
…ing directory
This pull request introduces a new `rm` command to the `mygit` CLI, enabling users to remove files from the working directory and/or the index, similar to the `git rm` command. The changes include adding the necessary functionality and integrating it into the CLI.

### Addition of the `rm` Command:

* **New `rm` Command Implementation**:
  - A new `rm` function was added in `src/porcelain/rm.py` to handle file removal from the index and optionally from the working directory. It includes error handling for missing files and index entries.

* **Integration into the CLI**:
  - The `rm` command was registered in `mygit/cli.py` using `typer`, with options to remove files from the index only (`--cached`) or both the index and working directory. User confirmation is required for non-cached deletions.
  - The `rm` function was imported into `mygit/cli.py` for use in the CLI.

### Codebase Updates:

* **Module Export**:
  - The `rm` function was added to the `src/porcelain/__init__.py` file to make it accessible as part of the `porcelain` module.