### PR TITLE
Reset

### DIFF
--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -18,6 +18,7 @@ from src.plumbing.show_ref import show_ref as show_ref_func
 from src.plumbing.rev_parse import rev_parse as rev_parse_func
 from src.porcelain.log import log as log_func
 from src.porcelain.rm import rm as rm_func
+from src.porcelain.reset import reset as reset_func
 
 app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
 
@@ -133,6 +134,22 @@ def rm_cmd(
         typer.echo(f"Fichier {file} supprimé de l'index seulement.")
     else:
         typer.echo(f"Fichier {file} supprimé de l'index et du répertoire de travail.")
+
+@app.command("reset")
+def reset_cmd(
+    commit_ref: str = typer.Argument(..., help="Référence du commit (SHA, HEAD, branche, etc.)"),
+    soft: bool = typer.Option(False, "--soft", help="Déplacer HEAD seulement"),
+    mixed: bool = typer.Option(False, "--mixed", help="Déplacer HEAD et réinitialiser l'index (défaut)"),
+    hard: bool = typer.Option(False, "--hard", help="Déplacer HEAD, réinitialiser l'index et le working directory")
+):
+    if soft:
+        mode = "soft"
+    elif hard:
+        mode = "hard"
+    else:
+        mode = "mixed"
+    reset_func(commit_ref, mode=mode)
+    typer.echo(f"reset --{mode} effectué sur {commit_ref}")
 
 if __name__ == "__main__":
     app()

--- a/src/plumbing/write_tree.py
+++ b/src/plumbing/write_tree.py
@@ -10,7 +10,7 @@ def write_tree(git_dir=".mygit", index_path=".mygit/index"):
 
     tree_content = "\n".join(tree_entries)
     tree_sha1 = hash_object_data(tree_content, "tree", git_dir, write=True)
-    print(tree_sha1)
+    return tree_sha1
 
 if __name__ == "__main__":
-    write_tree()
+    print(write_tree())

--- a/src/porcelain/__init__.py
+++ b/src/porcelain/__init__.py
@@ -1,2 +1,3 @@
 from .log import log
 from .rm import rm
+from .reset import reset

--- a/src/porcelain/reset.py
+++ b/src/porcelain/reset.py
@@ -77,7 +77,9 @@ def reset(commit_ref, mode="mixed", git_dir=GIT_DIR, index_path=INDEX_FILE):
             obj_type, blob_content = read_object(sha1, git_dir)
             if obj_type != "blob":
                 continue
-            os.makedirs(os.path.dirname(path), exist_ok=True)
+            dir_path = os.path.dirname(path)
+            if dir_path:
+                os.makedirs(dir_path, exist_ok=True)
             with open(path, "wb") as f:
                 f.write(blob_content)
     print(f"Working directory réinitialisé sur {tree_sha}")

--- a/src/porcelain/reset.py
+++ b/src/porcelain/reset.py
@@ -1,0 +1,100 @@
+import os
+import sys
+from src.plumbing.rev_parse import rev_parse
+from src.plumbing.cat_file import read_object
+
+GIT_DIR = ".mygit"
+INDEX_FILE = os.path.join(GIT_DIR, "index")
+
+# Utilitaire pour parser un commit (repris de log.py)
+def parse_commit(content):
+    lines = content.decode().splitlines()
+    commit_info = {}
+    for line in lines:
+        if line.startswith('tree '):
+            commit_info['tree'] = line[5:].strip()
+        elif line.startswith('parent '):
+            commit_info['parent'] = line[7:].strip()
+        elif line.startswith('author '):
+            commit_info['author'] = line[7:].strip()
+        elif line.startswith('committer '):
+            commit_info['committer'] = line[10:].strip()
+        elif line.strip() == '':
+            break
+    return commit_info
+
+def reset(commit_ref, mode="mixed", git_dir=GIT_DIR, index_path=INDEX_FILE):
+    # 1. Résoudre le commit
+    commit_sha = rev_parse(commit_ref, git_dir)
+    if not isinstance(commit_sha, str):
+        # rev_parse peut print et return None
+        print(f"Impossible de résoudre {commit_ref}", file=sys.stderr)
+        sys.exit(1)
+    # 2. Lire l'objet commit
+    obj_type, commit_content = read_object(commit_sha, git_dir)
+    if obj_type != "commit":
+        print(f"{commit_sha} n'est pas un commit.", file=sys.stderr)
+        sys.exit(1)
+    commit_info = parse_commit(commit_content)
+    tree_sha = commit_info["tree"]
+    # 3. --soft: déplacer HEAD
+    # HEAD peut pointer vers une ref ou contenir le SHA directement
+    head_path = os.path.join(git_dir, "HEAD")
+    with open(head_path) as f:
+        head_content = f.read().strip()
+    if head_content.startswith("ref: "):
+        ref_rel = head_content[5:].strip()
+        ref_path = os.path.join(git_dir, ref_rel)
+        os.makedirs(os.path.dirname(ref_path), exist_ok=True)
+        with open(ref_path, "w") as rf:
+            rf.write(commit_sha + "\n")
+    else:
+        with open(head_path, "w") as f:
+            f.write(commit_sha + "\n")
+    if mode == "soft":
+        print(f"HEAD déplacé vers {commit_sha}")
+        return
+    # 4. --mixed: réinitialiser l'index
+    obj_type, tree_content = read_object(tree_sha, git_dir)
+    if obj_type != "tree":
+        print(f"{tree_sha} n'est pas un tree.", file=sys.stderr)
+        sys.exit(1)
+    # On écrase l'index avec le contenu du tree
+    with open(index_path, "w") as idx:
+        for line in tree_content.decode().splitlines():
+            parts = line.strip().split()
+            if len(parts) == 3:
+                mode, path, sha1 = parts
+                idx.write(f"{mode} {path} {sha1}\n")
+    if mode == "mixed":
+        print(f"Index réinitialisé sur {tree_sha}")
+        return
+    # 5. --hard: réinitialiser le working directory
+    for line in tree_content.decode().splitlines():
+        parts = line.strip().split()
+        if len(parts) == 3:
+            mode, path, sha1 = parts
+            obj_type, blob_content = read_object(sha1, git_dir)
+            if obj_type != "blob":
+                continue
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "wb") as f:
+                f.write(blob_content)
+    print(f"Working directory réinitialisé sur {tree_sha}")
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Reset HEAD, index, and working directory to a given commit.")
+    parser.add_argument("commit_ref", help="Référence du commit (SHA, HEAD, branche, etc.)")
+    parser.add_argument("--soft", action="store_true", help="Déplacer HEAD seulement")
+    parser.add_argument("--mixed", action="store_true", help="Déplacer HEAD et réinitialiser l'index (défaut)")
+    parser.add_argument("--hard", action="store_true", help="Déplacer HEAD, réinitialiser l'index et le working directory")
+    parser.add_argument("--git-dir", default=GIT_DIR, help="Chemin du dossier .mygit")
+    args = parser.parse_args()
+    if args.soft:
+        mode = "soft"
+    elif args.hard:
+        mode = "hard"
+    else:
+        mode = "mixed"
+    reset(args.commit_ref, mode=mode, git_dir=args.git_dir, index_path=os.path.join(args.git_dir, "index")) 


### PR DESCRIPTION
This pull request introduces a new "reset" command to the `mygit` CLI, implements the corresponding functionality in the `reset` module, and refactors the commit logic to align more closely with Git's object model. Additionally, it improves modularity by returning the SHA-1 hash from the `write_tree` function instead of printing it.

### New functionality: Reset command
* Added a `reset` command to `mygit/cli.py`, allowing users to reset HEAD, the index, and the working directory with `--soft`, `--mixed`, or `--hard` options. This command is implemented using the new `reset_func` from `src/porcelain/reset.py`. (`[[1]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R138-R153)`, `[[2]](diffhunk://#diff-f70444bf9f31dd78259cdd6acbb44329546bbe2687a1d2d223be1b2485d85d14R21)`)
* Introduced the `reset` module in `src/porcelain/reset.py`, which includes functionality to resolve commits, update HEAD, reset the index, and reset the working directory based on the specified mode. (`[src/porcelain/reset.pyR1-R102](diffhunk://#diff-d02f3bb1cbed8b561c5e1c98c8a88b888a8ab39078802510907f1dc656f4f21aR1-R102)`)

### Refactoring: Commit logic
* Refactored the `commit` function in `src/porcelain/commit.py` to use the `write_tree` function for generating tree objects. The function now constructs Git-style commit objects with headers and stores them in the `.mygit/objects/` directory. (`[src/porcelain/commit.pyR24-R51](diffhunk://#diff-3af0b496f6b58022bd314a15c0c45b4fc3aa3eaf0308b94ac93c6e3632aa90c0R24-R51)`)
* Added imports for `hashlib` and `zlib` in `src/porcelain/commit.py` to support the new commit object creation process. (`[src/porcelain/commit.pyR4-R5](diffhunk://#diff-3af0b496f6b58022bd314a15c0c45b4fc3aa3eaf0308b94ac93c6e3632aa90c0R4-R5)`)

### Improvements: Tree writing
* Modified the `write_tree` function in `src/plumbing/write_tree.py` to return the SHA-1 hash of the tree object instead of printing it, improving reusability. (`[src/plumbing/write_tree.pyL13-R16](diffhunk://#diff-98e1eebc583e8cf235323460554b87829362e7abfae676f5b5a5c0d9336fa267L13-R16)`)

### Code organization
* Updated `src/porcelain/__init__.py` to include the new `reset` module, ensuring it is part of the `porcelain` package. (`[src/porcelain/__init__.pyR3](diffhunk://#diff-52609e633e5e356534f857ca061f2b0ef7778d5afaddf52c653dfe96f861b122R3)`)