### PR TITLE
add checkout command and implementation to switch branches or commits

### DIFF
--- a/mygit/cli.py
+++ b/mygit/cli.py
@@ -19,6 +19,7 @@ from src.plumbing.rev_parse import rev_parse as rev_parse_func
 from src.porcelain.log import log as log_func
 from src.porcelain.rm import rm as rm_func
 from src.porcelain.reset import reset as reset_func
+from src.porcelain.checkout import checkout as checkout_func
 
 app = typer.Typer(name="mygit", help="Une implémentation de Git en Python")
 
@@ -150,6 +151,15 @@ def reset_cmd(
         mode = "mixed"
     reset_func(commit_ref, mode=mode)
     typer.echo(f"reset --{mode} effectué sur {commit_ref}")
+
+@app.command("checkout")
+def checkout_cmd(
+    target: str = typer.Argument(..., help="Branche ou SHA à checkout"),
+    b: str = typer.Option(None, "-b", help="Créer une nouvelle branche et la checkout")
+):
+    """Bascule sur une branche ou un commit. Utilisez -b <branche> pour créer une branche."""
+    checkout_func(target, create_branch=b)
+    typer.echo(f"Checkout effectué sur {b if b else target}")
 
 if __name__ == "__main__":
     app()

--- a/src/porcelain/__init__.py
+++ b/src/porcelain/__init__.py
@@ -1,3 +1,4 @@
 from .log import log
 from .rm import rm
 from .reset import reset
+from .checkout import checkout

--- a/src/porcelain/checkout.py
+++ b/src/porcelain/checkout.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from src.plumbing.rev_parse import rev_parse
+from src.plumbing.cat_file import read_object
+from src.porcelain.reset import reset
+
+GIT_DIR = ".mygit"
+INDEX_FILE = os.path.join(GIT_DIR, "index")
+
+
+def checkout(target, create_branch=None, git_dir=GIT_DIR, index_path=INDEX_FILE):
+    head_path = os.path.join(git_dir, "HEAD")
+    refs_heads_dir = os.path.join(git_dir, "refs", "heads")
+    os.makedirs(refs_heads_dir, exist_ok=True)
+
+    # If -b <branch> is specified, create a new branch pointing to current HEAD
+    if create_branch:
+        branch_ref = os.path.join(refs_heads_dir, create_branch)
+        if os.path.exists(branch_ref):
+            print(f"Erreur : la branche '{create_branch}' existe déjà.", file=sys.stderr)
+            sys.exit(1)
+        # Get current HEAD commit
+        current_commit = rev_parse("HEAD", git_dir)
+        with open(branch_ref, "w") as f:
+            f.write(current_commit + "\n")
+        # Now set target to the new branch
+        target = create_branch
+
+    # Resolve the target (branch name, tag, or SHA)
+    commit_sha = rev_parse(target, git_dir)
+    # Check if target is a branch
+    branch_path = os.path.join(refs_heads_dir, target)
+    if os.path.exists(branch_path):
+        # Update HEAD to point to the branch
+        with open(head_path, "w") as f:
+            f.write(f"ref: refs/heads/{target}\n")
+    else:
+        # Detached HEAD
+        with open(head_path, "w") as f:
+            f.write(commit_sha + "\n")
+    # Update index and working directory to match the commit
+    reset(commit_sha, mode="hard", git_dir=git_dir, index_path=index_path)
+    print(f"Switched to {'branch ' + target if os.path.exists(branch_path) else 'commit ' + commit_sha}")
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Switch to a branch or commit. Optionally create a new branch.")
+    parser.add_argument("target", help="Nom de la branche ou SHA du commit à checkout")
+    parser.add_argument("-b", dest="create_branch", help="Créer une nouvelle branche et la checkout", default=None)
+    parser.add_argument("--git-dir", default=GIT_DIR, help="Chemin du dossier .mygit")
+    args = parser.parse_args()
+    checkout(args.target, create_branch=args.create_branch, git_dir=args.git_dir, index_path=os.path.join(args.git_dir, "index")) 


### PR DESCRIPTION
This pull request introduces a new `checkout` command to the `mygit` CLI, enabling users to switch branches or commits and optionally create new branches. The changes include integrating the `checkout` functionality into the CLI, implementing the underlying logic in the `checkout` module, and updating imports to support this feature.

### New `checkout` command integration:

* **Command addition in `mygit/cli.py`:** Added a new `checkout` command to the CLI, allowing users to switch to a branch or commit and optionally create a new branch using the `-b` option. The command provides user-friendly feedback after execution.
* **Import update in `mygit/cli.py`:** Imported the `checkout` function from `src.porcelain.checkout` to enable the new CLI command.

### Implementation of `checkout` functionality:

* **New `checkout` module in `src/porcelain/checkout.py`:** Implemented the core logic for the `checkout` command, including resolving branch names or commit SHAs, updating the `HEAD` reference, creating new branches, and resetting the working directory and index. This module also provides a standalone CLI interface for testing purposes.

### Supporting changes:

* **Import update in `src/porcelain/__init__.py`:** Added the `checkout` function to the `porcelain` package's public API for easier access and modularity.